### PR TITLE
05-10-2025

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,11 @@
 
 ## Build, Test & Development Commands
 - `npx sass sass/style.scss style.css --no-source-map` rebuilds stylesheets (`--watch` for live edits).
-- After JS/HTML changes reload via SillyTavern `Settings → Extensions → Reload`.
+- After JS/HTML changes reload via SillyTavern `Settings -> Extensions -> Reload`.
 - In the browser console inspect `window.trackerEnhanced` to view runtime state or toggle debug logging.
 
 ## Coding Style & Conventions
-- ES modules, double quotes, trailing semicolons. Core logic uses tabs; selective UI helpers use four spaces—match the file.
+- ES modules, double quotes, trailing semicolons. Core logic uses tabs; selective UI helpers use four spaces; match the file.
 - Naming: PascalCase classes, camelCase functions/vars, SCREAMING_SNAKE_CASE constants, DOM IDs prefixed with `tracker_enhanced_`.
 - Use provided `debug/log/warn/error` helpers for console output so debug mode can silence them globally.
 
@@ -20,7 +20,7 @@
 - Tracker auto-generation hooks fire from `onGenerateAfterCommands`, `onMessageSent/Received`, and render callbacks. SillyTavern emits a `generation_after_commands` dry-run immediately after `chat_id_changed`; we now bail early and log `GENERATION_AFTER_COMMANDS dry run skip { type: "normal", dryRun: true, ... }` to confirm no request is sent.
 - The first real turn after a reload still fires a second `generation_after_commands` with `dryRun: false`. Look for the log payload `(3) [undefined, options, false]` before tracker generation starts. If that never appears, reload the extension to clear stale `chat_metadata`.
 - `addTrackerToMessage` writes tracker data before the DOM exists; previews/interface updates must run in `onUserMessageRendered`/`onCharacterMessageRendered`. Skipping those handlers after a tracker exists hides UI updates.
-- When investigating tracker gaps, capture the full console sequence (chat open → user turn → character reply). Two sequential generation calls are expected in single-stage mode: one for the previous message, one for the newly rendered message. Only unexpected dry-run omissions should be treated as regressions.
+- When investigating tracker gaps, capture the full console sequence (chat open -> user turn -> character reply). Two sequential generation calls are expected in single-stage mode: one for the previous message, one for the newly rendered message. Only unexpected dry-run omissions should be treated as regressions.
 
 ## Testing Workflow
 - Manual validation only: stage chats, send user/character turns, run `/tracker save`, inspect preview pane, and watch console for `[tracker-enhanced]` logs or unexpected mutex captures.
@@ -32,3 +32,8 @@
 
 ## Migration Context
 - Development moved from Claude to Codex agents. Keep AGENTS.md updated with key learnings (like the tracker generation findings above) so future compactions retain context.
+
+## Environment Notes
+- Windows 11 with PowerShell 7; prefer launching commands via `pwsh -NoLogo -NoProfile` to avoid user profile noise.
+- Long embedded strings in PowerShell inline commands are brittle, so use here-strings or drop a temporary script file (e.g., write a `.py` helper) when you need heavy quoting or backslashes.
+- Python resolves through pyenv shims; prefer explicit `python` but be ready to pass `encoding="utf-8"` when reading repo files to dodge the default `gbk` codec.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ An advanced, feature-rich tracker extension for SillyTavern that provides compre
 
 ## Changelog
 
+05-10-2025
+- Added a configurable **“Roleplay Injection Prompt”**, allowing injected tracker payloads to begin with a short guidance line.  
+  - This helps the roleplay LLM understand the purpose of the tracker.  
+- Removed **Inline** and **Two-Stage** generation models, along with their pipelines and settings.  
+  - *Inline* simply injected into the main chat and asked the roleplay LLM to handle the tracker task, which was counterintuitive since it bypassed our independent connection.  
+  - *Two-Stage* sent two requests, which I never found useful.  
+  - Both were removed to simplify pipelines and settings.
+
 02-10-2025
 - Added AGPL-3.0 LICENSE file (based on SillyTavern’s official license).
 - Added debug log marker 💉 to indicate when prompt injection occurs.

--- a/html/settings.html
+++ b/html/settings.html
@@ -90,7 +90,6 @@
 						<button id="tracker_enhanced_preset_export" class="menu_button fa-solid fa-file-export interactable" title="Export current tracker enhanced preset"></button>
 					</div>
 				</div>
-			</div>
 			<hr class="sysHR" />
 
 			<details>
@@ -98,26 +97,12 @@
 				<!-- Preset Related Fields -->
 				<div id="preset_related_fields">
 					<!-- Generation Mode -->
-					<div class="tracker-block m-b-1 m-t-1">
-						<label for="tracker_enhanced_generation_mode">Generation Mode</label><br />
-						<small
-							>Select how the tracker updates:<br />
-							- Inline: Adds the tracker to the beginning of every message.<br />
-							- Single-Stage: Sends one prompt to update the tracker.<br />
-							- Two-Stage: First summarizes changes, then updates the tracker.</small
-						><br />
-						<select id="tracker_enhanced_generation_mode" class="text_pole">
-							<option value="inline">Inline</option>
-							<option value="single-stage">Single-Stage</option>
-							<option value="two-stage">Two-Stage</option>
-						</select>
-					</div>
 					<!-- Tracker Templates -->
 					<div id="generate_context_section" class="tracker-block m-b-1 m-t-1">
 						<label for="tracker_enhanced_context_prompt">Context Template</label><br />
 						<small
 							>Define the template for generating the tracker. Use macros like:<br />
-							{{trackerSystemPrompt}}, {{characterDescriptions}}, {{trackerExamples}}, {{recentMessages}}, {{currentTracker}}, {{trackerFormat}}, {{trackerFieldPrompt}}, {{firstStageMessage}} (Only in two stage mode).</small
+							{{trackerSystemPrompt}}, {{characterDescriptions}}, {{trackerExamples}}, {{recentMessages}}, {{currentTracker}}, {{trackerFormat}}, {{trackerFieldPrompt}}.</small
 						><br />
 						<textarea id="tracker_enhanced_context_prompt" class="text_pole" rows="5"></textarea>
 					</div>
@@ -133,7 +118,7 @@
 						<label for="tracker_enhanced_request_prompt">Request Prompt</label><br />
 						<small
 							>Set the request prompt for generating the tracker. Available macros include:<br />
-							{{trackerFieldPrompt}}, {{trackerFormat}}, {{message}} (last message), {{firstStageMessage}} (Two-Stage mode only).</small
+							{{trackerFieldPrompt}}, {{trackerFormat}}, {{message}} (last message).</small
 						><br />
 						<textarea id="tracker_enhanced_request_prompt" class="text_pole" rows="5"></textarea>
 					</div>
@@ -152,47 +137,6 @@
 						><br />
 						<textarea id="tracker_enhanced_recent_messages" class="text_pole" rows="5"></textarea>
 					</div>
-					<div id="inline_request_section" class="tracker-block m-b-1 m-t-1">
-						<label for="tracker_enhanced_inline_request_prompt">Inline Request Prompt</label><br />
-						<small
-							>Configure the prompt injected at the start of every message in Inline mode. Use macros like:<br />
-							{{trackerFieldPrompt}}, {{trackerFormat}}, {{message}}.</small
-						><br />
-						<textarea id="tracker_enhanced_inline_request_prompt" class="text_pole" rows="5"></textarea>
-					</div>
-					<div id="message_summarization_section">
-						<div class="tracker-block m-b-1 m-t-1">
-							<label for="tracker_enhanced_message_summarization_context_template">Message Summarization Context Template</label><br />
-							<small
-								>Template used for summarizing the last message. Macros available:<br />
-								{{trackerSystemPrompt}}, {{characterDescriptions}}, {{trackerExamples}}, {{recentMessages}}, {{currentTracker}}, {{trackerFormat}}, {{trackerFieldPrompt}}, {{messageSummarizationSystemPrompt}}.</small
-							><br />
-							<textarea id="tracker_enhanced_message_summarization_context_template" class="text_pole" rows="5"></textarea>
-						</div>
-						<div class="tracker-block m-b-1 m-t-1">
-							<label for="tracker_enhanced_message_summarization_system_prompt">Message Summarization System Prompt</label><br />
-							<small
-								>System-level prompt for summarizing the last message. Available macros:<br />
-								{{charNames}}, {{defaultTracker}}, {{trackerFormat}}.</small
-							><br />
-							<textarea id="tracker_enhanced_message_summarization_system_prompt" class="text_pole" rows="5"></textarea>
-						</div>
-						<div class="tracker-block m-b-1 m-t-1">
-							<label for="tracker_enhanced_message_summarization_request_prompt">Message Summarization Request Prompt</label><br />
-							<small
-								>Set the request prompt for summarizing the last message. Macros:<br />
-								{{trackerFieldPrompt}}, {{trackerFormat}}, {{message}}.</small
-							><br />
-							<textarea id="tracker_enhanced_message_summarization_request_prompt" class="text_pole" rows="5"></textarea>
-						</div>
-						<div class="tracker-block m-b-1 m-t-1">
-							<label for="tracker_enhanced_recent_messages">Message Summarization Recent Messages Template</label><br />
-							<small
-								>Template for recent messages in the tracker. Macros include:<br />
-								{{char}}, {{message}}, {{tracker}}, {{#if tracker}}...{{/if}}.</small
-							><br />
-							<textarea id="tracker_enhanced_message_summarization_recent_messages" class="text_pole" rows="5"></textarea>
-						</div>
 					</div>
 					<div class="tracker-block m-b-1 m-t-1">
 						<label for="tracker_enhanced_character_description">Character Description Template</label><br />
@@ -233,12 +177,13 @@
 					</div>
 				</div>
 			</details>
+			</div>
 			<hr class="sysHR" />
 
 			<!-- Other Settings -->
 			<div class="tracker-block m-b-1 m-t-1">
 				<label for="tracker_enhanced_number_of_messages">Number of Recent Messages to Include</label><br />
-				<small>Set how many recent messages are included in tracker generation prompts. In Inline mode, this defines how many messages have trackers added.</small><br />
+				<small>Set how many recent messages are included in tracker generation prompts.</small><br />
 				<input max="99" min="1" class="text_pole" id="tracker_enhanced_number_of_messages" type="number" />
 			</div>
 			<div class="tracker-block m-b-1 m-t-1">

--- a/html/settings.html
+++ b/html/settings.html
@@ -177,7 +177,6 @@
 					</div>
 				</div>
 			</details>
-			</div>
 			<hr class="sysHR" />
 
 			<!-- Other Settings -->

--- a/html/settings.html
+++ b/html/settings.html
@@ -138,6 +138,13 @@
 						<textarea id="tracker_enhanced_request_prompt" class="text_pole" rows="5"></textarea>
 					</div>
 					<div class="tracker-block m-b-1 m-t-1">
+						<label for="tracker_enhanced_roleplay_prompt">Roleplay Injection Prompt</label><br />
+						<small
+							>Additional guidance inserted ahead of the tracker block when we inject into SillyTavern prompts. Keep it concise and focused on diegetic knowledge boundaries.</small
+						><br />
+						<textarea id="tracker_enhanced_roleplay_prompt" class="text_pole" rows="3"></textarea>
+					</div>
+					<div class="tracker-block m-b-1 m-t-1">
 						<label for="tracker_enhanced_recent_messages">Recent Messages Template</label><br />
 						<small
 							>Template for recent messages in the tracker. Macros include:<br />

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -743,6 +743,8 @@ const minimumDepth = 0;
 
 const responseLength = 0;
 
+const roleplayPrompt = "The tracker block records factual story data for reference only. Tracker is not a character. Base your character's knowledge only on what they could logically know from these facts.";
+
 //#endregion
 
 export const defaultSettings = {
@@ -780,6 +782,7 @@ export const defaultSettings = {
 	generateFromMessage: generateFromMessage,
 	minimumDepth: minimumDepth,
 	responseLength: responseLength,
+	roleplayPrompt: roleplayPrompt,
 	selectedPreset: "Default-SingleStage",
 	presets: {
 		"Default-SingleStage": {
@@ -789,6 +792,7 @@ export const defaultSettings = {
 			generateSystemPrompt: generateSystemPrompt,
 			generateRequestPrompt: generateRequestPrompt,
 			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
+			roleplayPrompt: roleplayPrompt,
 
 			messageSummarizationContextTemplate: "",
 			messageSummarizationSystemPrompt: "",
@@ -810,6 +814,7 @@ export const defaultSettings = {
 			generateSystemPrompt: twoStageGenerateSystemPrompt,
 			generateRequestPrompt: twoStageGenerateRequestPrompt,
 			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
+			roleplayPrompt: roleplayPrompt,
 
 			messageSummarizationContextTemplate: messageSummarizationContextTemplate,
 			messageSummarizationSystemPrompt: messageSummarizationSystemPrompt,
@@ -831,6 +836,7 @@ export const defaultSettings = {
 			generateSystemPrompt: generateSystemPrompt,
 			generateRequestPrompt: generateRequestPrompt,
 			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
+			roleplayPrompt: roleplayPrompt,
 
 			messageSummarizationContextTemplate: "",
 			messageSummarizationSystemPrompt: "",

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -1,9 +1,7 @@
 //#region Setting Enums
 
 export const generationModes = {
-	INLINE: "inline",
 	SINGLE_STAGE: "single-stage",
-	TWO_STAGE: "two-stage",
 };
 
 export const generationTargets = {
@@ -24,177 +22,6 @@ export const PREVIEW_PLACEMENT = {
 	APPEND: "append",
 	PREPEND: "prepend",
 };
-
-//#endregion
-
-//#region Two Stage
-
-const twoStageGenerateContextTemplate = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>
-
-{{trackerSystemPrompt}}
-
-<!-- Start of Context -->
-
-{{characterDescriptions}}
-
-### Example Trackers
-<!-- Start of Example Trackers -->
-{{trackerExamples}}
-<!-- End of Example Trackers -->
-
-### Current Tracker
-<tracker>
-{{currentTracker}}
-</tracker>
-
-### Changes List
-{{firstStageMessage}}
-
-<!-- End of Context --><|eot_id|>`;
-const twoStageGenerateSystemPrompt = `You are a Scene Tracker Assistant, tasked with providing clear, consistent, and structured updates to a scene tracker for a roleplay. Use the provided changes list, previous tracker details, and recent context to accurately update the tracker. Your response must follow the specified {{trackerFormat}} structure exactly, ensuring that each field is filled and complete.
-
-### Key Instructions:
-1. **Tracker Format**: Always respond with a complete tracker in {{trackerFormat}} format. Every field must be present in the response, even if unchanged. Do not omit fields or change the {{trackerFormat}} structure.
-2. **Incorporate Changes List**:
-   - Use the provided changes list to guide updates. Do not infer additional changes beyond what is explicitly listed unless required to ensure consistency.
-   - If specific information is missing, rely on prior descriptions, logical inferences, or default details.
-3. **Default Assumptions for Missing Information**: 
-   - **Character Details**: If no new details are provided for a character, assume reasonable defaults based on previous entries or context.
-   - **Outfit**: Include complete outfit details for each character, specifying underwear explicitly. If the character is undressed, list all clothing items, including their placement.
-   - **StateOfDress**: Describe how put-together or disheveled the character appears, reflecting any updates in the changes list.
-4. **Incremental Time Progression**: 
-   - Adjust time incrementally based on the changes list, typically only a few seconds per update unless otherwise specified.
-   - Format the time as "HH:MM:SS; MM/DD/YYYY (Day Name)".
-5. **Context-Appropriate Times**: 
-   - Ensure the time aligns with the scene's setting and context (e.g., operating hours for public venues).
-6. **Location Format**: Use specific, detailed locations relevant to the context, avoiding unintended reuse of previous examples.
-7. **Consistency**: Maintain {{trackerFormat}} structure precisely. If no changes occur in a field, retain the most recent value.
-8. **Topics Format**: Ensure topics are concise and relevant to the scene (e.g., one- or two-word keywords).
-9. **Avoid Redundancies**: Only include details provided or logically inferred. Avoid speculative or unnecessary additions.
-
-### Tracker Template
-Return your response in the following {{trackerFormat}} structure, following this format precisely:
-
-\`\`\`
-<tracker>
-{{defaultTracker}}
-</tracker>
-\`\`\`
-
-### Important Reminders:
-1. **Changes List**: Use the provided changes list to guide updates to the tracker. Do not detect additional changes beyond what is explicitly stated.
-2. **Recent Messages and Current Tracker**: Consider the recent messages and the current tracker to ensure accuracy and context alignment.
-3. **Structured Response**: Respond with the full tracker in {{trackerFormat}}. Do not add extra information outside of the tracker structure.
-4. **Complete Entries**: Always provide the full tracker, even if the changes are minor or limited to a single field.
-
-Your primary objective is to ensure clarity, consistency, and structured updates for scene tracking in {{trackerFormat}} format, accurately reflecting the provided changes.`;
-const twoStageGenerateRequestPrompt = `[Use the provided changes list below to update the current scene tracker based on explicit details. Do not infer additional changes beyond those listed. Pause and ensure only the tracked data is provided, formatted in {{trackerFormat}}. Avoid adding, omitting, or rearranging fields unless specified. Respond with the full tracker every time.
-
-### Changes List:
-{{firstStageMessage}}
-
-### Response Rules:
-{{trackerFieldPrompt}}
-
-Ensure the response remains consistent, strictly follows this structure in {{trackerFormat}}, and omits any extra data or deviations. You MUST enclose the tracker in <tracker></tracker> tags.]`;
-
-const messageSummarizationContextTemplate = `<|begin_of_text|><|start_header_id|>system<|end_header_id|>
-
-{{messageSummarizationSystemPrompt}}
-
-<!-- Start of Context -->
-
-### Current Tracker
-<tracker>
-{{currentTracker}}
-</tracker>
-
-### Recent Messages
-{{recentMessages}}
-
-### Tracker Field Guidelines
-{{trackerFieldPrompt}}
-
-<!-- End of Context -->
-<|eot_id|>`;
-const messageSummarizationSystemPrompt = `You are a Scene Change Detector. Your task is to analyze the latest message and identify all relevant changes or updates for a scene tracker.
-
-### Instructions:
-1. **Detect Changes**:
-   - Compare the latest message to the recent context and identify explicit or logical updates based on the described actions, emotions, and scene details.
-   - Focus on changes that affect the scene tracker, prioritizing the types of updates outlined in the **Tracker Field Guidelines** provided in the context.
-
-2. **Output Format**:
-   - Provide a **markdown list** describing each identified change.
-   - Each entry must be concise, specific, and written in plain language.
-   - Avoid speculative updates or unrelated information. If no changes are detected, respond with:
-   \`\`\`
-   - No changes identified.
-   \`\`\`
-
-3. **General Handling**:
-   - Use the latest message and recent context to determine updates. Focus on elements such as:
-     - {{trackerFieldPrompt}} (Defined dynamically in the context).
-   - Include specific updates to characters, actions, time, emotional tone, location, or any other field defined in the tracker format.
-
-4. **Example Output**:
-   \`\`\`
-   - The time has advanced by a few seconds.
-   - Cohee is leading Kaldigo through the mall, pointing out stores and holding his hand.
-   - Cohee's tone is excited, reflecting her playful dialogue and energetic gestures.
-   \`\`\`
-
-Your goal is to provide a concise and accurate list of changes that will inform updates to the scene tracker.`;
-const messageSummarizationRequestPrompt = `Analyze the most recent message provided below and compare it to the recent context and tracker to identify changes. Your response must follow the rules provided and use the specified **markdown list** format.
-
-### Recent Message:
-{{message}}
-
-### Response Rules:
-1. Compare the recent message to the current tracker and context to detect changes.
-2. Focus on changes related to the fields outlined in {{trackerFieldPrompt}}, such as time, location, characters, or other context-specific updates.
-3. List all detected changes in markdown list format. Avoid any additional formatting.
-4. Use concise and specific language. Base updates only on explicit or inferred details.
-
-### Output Format:
-\`\`\`
-- The time has advanced by a few seconds.
-- Cohee is leading Kaldigo through the mall, pointing out stores and holding his hand.
-- Cohee’s tone is excited, reflecting her playful dialogue and energetic gestures.
-\`\`\`
-
-Provide only the list of changes as your response.`;
-const messageSummarizationRecentMessagesTemplate = `{{char}}: {{message}}`;
-
-//#endregion
-
-//#region Inline
-
-const inlineRequestPrompt = `[At the beginning of every response, prepend an updated tracker to reflect the current scene. Use the provided tracker format, field guidelines, and default structure to ensure consistency and accuracy.
-
-### Instructions:
-1. **Tracker Updates**:
-   - Update the tracker fields based on the latest message and logical inferences using:
-     - The provided tracker field guidelines.
-     - The current tracker as the base for continuity.
-     - Logical assumptions if explicit details are missing, informed by prior context.
-2. **Time Progression**:
-   - Progress time incrementally unless a time skip is explicitly indicated (e.g., sleeping, traveling, or user requests).
-3. **Weather Updates**:
-   - Update or infer weather conditions based on the setting, time, and scene location.
-4. **Tracker Format**:
-   - Use the exact tracker structure provided in the default tracker template.
-   - Ensure all fields are present and complete, even if unchanged.
-
-### Tracker Format:
-<tracker>
-{{defaultTracker}}
-</tracker>
-
-### Tracker Guidelines:
-{{trackerFieldPrompt}}
-
-Ensure every response starts with a tracker in the specified format, followed by the regular message content.]`;
 
 //#endregion
 
@@ -747,113 +574,55 @@ const roleplayPrompt = "The tracker block records factual story data for referen
 
 //#endregion
 
-export const defaultSettings = {
-	enabled: true,
-	selectedProfile: "current",
-	selectedCompletionPreset: "current",
-	generationTarget: generationTargets.BOTH,
-	showPopupFor: generationTargets.NONE,
-	trackerFormat: trackerFormat.YAML,
-
-	generationMode: generationModes.SINGLE_STAGE,
-
-	generateContextTemplate: generateContextTemplate,
-	generateSystemPrompt: generateSystemPrompt,
-	generateRequestPrompt: generateRequestPrompt,
-	generateRecentMessagesTemplate: generateRecentMessagesTemplate,
-
-	messageSummarizationContextTemplate: "",
-	messageSummarizationSystemPrompt: "",
-	messageSummarizationRequestPrompt: "",
-	messageSummarizationRecentMessagesTemplate: "",
-
-	inlineRequestPrompt: "",
-
-	characterDescriptionTemplate: characterDescriptionTemplate,
-
-	mesTrackerTemplate: mesTrackerTemplate,
-	mesTrackerJavascript: mesTrackerJavascript,
-	trackerDef: trackerDef,
-
-	trackerPreviewSelector: trackerPreviewSelector,
-	trackerPreviewPlacement: trackerPreviewPlacement,
-
-	numberOfMessages: numberOfMessages,
-	generateFromMessage: generateFromMessage,
-	minimumDepth: minimumDepth,
-	responseLength: responseLength,
-	roleplayPrompt: roleplayPrompt,
-	selectedPreset: "Default-SingleStage",
-	presets: {
-		"Default-SingleStage": {
-			generationMode: generationModes.SINGLE_STAGE,
-
-			generateContextTemplate: generateContextTemplate,
-			generateSystemPrompt: generateSystemPrompt,
-			generateRequestPrompt: generateRequestPrompt,
-			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
-			roleplayPrompt: roleplayPrompt,
-
-			messageSummarizationContextTemplate: "",
-			messageSummarizationSystemPrompt: "",
-			messageSummarizationRequestPrompt: "",
-			messageSummarizationRecentMessagesTemplate: "",
-
-			inlineRequestPrompt: "",
-
-			characterDescriptionTemplate: characterDescriptionTemplate,
-
-			mesTrackerTemplate: mesTrackerTemplate,
-			mesTrackerJavascript: mesTrackerJavascript,
-			trackerDef: trackerDef,
-		},
-		"Default-TwoStage": {
-			generationMode: generationModes.TWO_STAGE,
-
-			generateContextTemplate: twoStageGenerateContextTemplate,
-			generateSystemPrompt: twoStageGenerateSystemPrompt,
-			generateRequestPrompt: twoStageGenerateRequestPrompt,
-			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
-			roleplayPrompt: roleplayPrompt,
-
-			messageSummarizationContextTemplate: messageSummarizationContextTemplate,
-			messageSummarizationSystemPrompt: messageSummarizationSystemPrompt,
-			messageSummarizationRequestPrompt: messageSummarizationRequestPrompt,
-			messageSummarizationRecentMessagesTemplate: messageSummarizationRecentMessagesTemplate,
-
-			inlineRequestPrompt: "",
-
-			characterDescriptionTemplate: characterDescriptionTemplate,
-
-			mesTrackerTemplate: mesTrackerTemplate,
-			mesTrackerJavascript: mesTrackerJavascript,
-			trackerDef: trackerDef,
-		},
-		"Default-Inline": {
-			generationMode: generationModes.INLINE,
-
-			generateContextTemplate: generateContextTemplate,
-			generateSystemPrompt: generateSystemPrompt,
-			generateRequestPrompt: generateRequestPrompt,
-			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
-			roleplayPrompt: roleplayPrompt,
-
-			messageSummarizationContextTemplate: "",
-			messageSummarizationSystemPrompt: "",
-			messageSummarizationRequestPrompt: "",
-			messageSummarizationRecentMessagesTemplate: "",
-
-			inlineRequestPrompt: inlineRequestPrompt,
-
-			characterDescriptionTemplate: characterDescriptionTemplate,
-
-			mesTrackerTemplate: mesTrackerTemplate,
-			mesTrackerJavascript: mesTrackerJavascript,
-			trackerDef: trackerDef,
-		},
-	},
-	debugMode: false,
-	trackerInjectionEnabled: true,
+export const defaultSettings = {
+	enabled: true,
+	selectedProfile: "current",
+	selectedCompletionPreset: "current",
+	generationTarget: generationTargets.BOTH,
+	showPopupFor: generationTargets.NONE,
+	trackerFormat: trackerFormat.YAML,
+
+	generationMode: generationModes.SINGLE_STAGE,
+
+	generateContextTemplate: generateContextTemplate,
+	generateSystemPrompt: generateSystemPrompt,
+	generateRequestPrompt: generateRequestPrompt,
+	generateRecentMessagesTemplate: generateRecentMessagesTemplate,
+
+	characterDescriptionTemplate: characterDescriptionTemplate,
+
+	mesTrackerTemplate: mesTrackerTemplate,
+	mesTrackerJavascript: mesTrackerJavascript,
+	trackerDef: trackerDef,
+
+	trackerPreviewSelector: trackerPreviewSelector,
+	trackerPreviewPlacement: trackerPreviewPlacement,
+
+	numberOfMessages: numberOfMessages,
+	generateFromMessage: generateFromMessage,
+	minimumDepth: minimumDepth,
+	responseLength: responseLength,
+	roleplayPrompt: roleplayPrompt,
+	selectedPreset: "Default-SingleStage",
+	presets: {
+		"Default-SingleStage": {
+			generationMode: generationModes.SINGLE_STAGE,
+
+			generateContextTemplate: generateContextTemplate,
+			generateSystemPrompt: generateSystemPrompt,
+			generateRequestPrompt: generateRequestPrompt,
+			generateRecentMessagesTemplate: generateRecentMessagesTemplate,
+			roleplayPrompt: roleplayPrompt,
+
+			characterDescriptionTemplate: characterDescriptionTemplate,
+
+			mesTrackerTemplate: mesTrackerTemplate,
+			mesTrackerJavascript: mesTrackerJavascript,
+			trackerDef: trackerDef,
+		},
+	},
+	debugMode: false,
+	trackerInjectionEnabled: true,
 };
 
 // Default test data for development

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -39,7 +39,7 @@ export async function initSettings() {
 	const currentSettings = { ...extensionSettings };
 
 	if (!currentSettings.trackerDef) {
-		const allowedKeys = ["enabled", "generateContextTemplate", "generateSystemPrompt", "generateRequestPrompt", "characterDescriptionTemplate", "mesTrackerTemplate", "numberOfMessages", "responseLength", "debugMode"];
+		const allowedKeys = ["enabled", "generateContextTemplate", "generateSystemPrompt", "generateRequestPrompt", "roleplayPrompt", "characterDescriptionTemplate", "mesTrackerTemplate", "numberOfMessages", "responseLength", "debugMode"];
 
 		const newSettings = {
 			...defaultSettings,
@@ -132,6 +132,7 @@ function setSettingsInitialValues() {
 	$("#tracker_enhanced_context_prompt").val(extensionSettings.generateContextTemplate);
 	$("#tracker_enhanced_system_prompt").val(extensionSettings.generateSystemPrompt);
 	$("#tracker_enhanced_request_prompt").val(extensionSettings.generateRequestPrompt);
+	$("#tracker_enhanced_roleplay_prompt").val(extensionSettings.roleplayPrompt);
 	$("#tracker_enhanced_recent_messages").val(extensionSettings.generateRecentMessagesTemplate);
 	$("#tracker_enhanced_inline_request_prompt").val(extensionSettings.inlineRequestPrompt);
 	$("#tracker_enhanced_message_summarization_context_template").val(extensionSettings.messageSummarizationContextTemplate);
@@ -191,6 +192,7 @@ function registerSettingsListeners() {
 	$("#tracker_enhanced_context_prompt").on("input", onSettingInputareaInput("generateContextTemplate"));
 	$("#tracker_enhanced_system_prompt").on("input", onSettingInputareaInput("generateSystemPrompt"));
 	$("#tracker_enhanced_request_prompt").on("input", onSettingInputareaInput("generateRequestPrompt"));
+	$("#tracker_enhanced_roleplay_prompt").on("input", onSettingInputareaInput("roleplayPrompt"));
 	$("#tracker_enhanced_recent_messages").on("input", onSettingInputareaInput("generateRecentMessagesTemplate"));
 	$("#tracker_enhanced_inline_request_prompt").on("input", onSettingInputareaInput("inlineRequestPrompt"));
 	$("#tracker_enhanced_message_summarization_context_template").on("input", onSettingInputareaInput("messageSummarizationContextTemplate"));
@@ -653,6 +655,7 @@ function getCurrentPresetSettings() {
 		generateSystemPrompt: extensionSettings.generateSystemPrompt,
 		generateRequestPrompt: extensionSettings.generateRequestPrompt,
 		generateRecentMessagesTemplate: extensionSettings.generateRecentMessagesTemplate,
+		roleplayPrompt: extensionSettings.roleplayPrompt,
 		
 		messageSummarizationContextTemplate: extensionSettings.messageSummarizationContextTemplate,
 		messageSummarizationSystemPrompt: extensionSettings.messageSummarizationSystemPrompt,

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -3,7 +3,7 @@ import { getContext } from '../../../../../../scripts/extensions.js';
 
 import { extensionFolderPath, extensionSettings } from "../../index.js";
 import { error, debug, toTitleCase } from "../../lib/utils.js";
-import { defaultSettings, generationModes, generationTargets } from "./defaultSettings.js";
+import { defaultSettings, generationTargets } from "./defaultSettings.js";
 import { generationCaptured } from "../../lib/interconnection.js";
 import { TrackerPromptMakerModal } from "../ui/trackerPromptMakerModal.js";
 import { TrackerTemplateGenerator } from "../ui/components/trackerTemplateGenerator.js";
@@ -98,7 +98,6 @@ async function loadSettingsUI() {
 
 		setSettingsInitialValues();
 		registerSettingsListeners();
-		updateFieldVisibility(extensionSettings.generationMode);
 		
 		// Initialize Development Test UI
 		DevelopmentTestUI.init();
@@ -118,10 +117,8 @@ function setSettingsInitialValues() {
 	updatePresetDropdown();
 	initializeOverridesDropdowns();
 	updatePopupDropdown();
-	updateFieldVisibility(extensionSettings.generationMode);
 
 	$("#tracker_enhanced_enable").prop("checked", extensionSettings.enabled);
-	$("#tracker_enhanced_generation_mode").val(extensionSettings.generationMode);
 	$("#tracker_enhanced_generation_target").val(extensionSettings.generationTarget);
 	$("#tracker_enhanced_show_popup_for").val(extensionSettings.showPopupFor);
 	$("#tracker_enhanced_format").val(extensionSettings.trackerFormat);
@@ -134,11 +131,6 @@ function setSettingsInitialValues() {
 	$("#tracker_enhanced_request_prompt").val(extensionSettings.generateRequestPrompt);
 	$("#tracker_enhanced_roleplay_prompt").val(extensionSettings.roleplayPrompt);
 	$("#tracker_enhanced_recent_messages").val(extensionSettings.generateRecentMessagesTemplate);
-	$("#tracker_enhanced_inline_request_prompt").val(extensionSettings.inlineRequestPrompt);
-	$("#tracker_enhanced_message_summarization_context_template").val(extensionSettings.messageSummarizationContextTemplate);
-	$("#tracker_enhanced_message_summarization_system_prompt").val(extensionSettings.messageSummarizationSystemPrompt);
-	$("#tracker_enhanced_message_summarization_request_prompt").val(extensionSettings.messageSummarizationRequestPrompt);
-	$("#tracker_enhanced_message_summarization_recent_messages").val(extensionSettings.messageSummarizationRecentMessagesTemplate);
 	$("#tracker_enhanced_character_description").val(extensionSettings.characterDescriptionTemplate);
 	$("#tracker_enhanced_mes_tracker_template").val(extensionSettings.mesTrackerTemplate);
 	$("#tracker_enhanced_mes_tracker_javascript").val(extensionSettings.mesTrackerJavascript);
@@ -174,7 +166,6 @@ function registerSettingsListeners() {
 
 	// Settings fields
 	$("#tracker_enhanced_enable").on("input", onSettingCheckboxInput("enabled"));
-	$("#tracker_enhanced_generation_mode").on("change", onGenerationModeChange);
 	$("#tracker_enhanced_generation_target").on("change", onSettingSelectChange("generationTarget"));
 	$("#tracker_enhanced_show_popup_for").on("change", onSettingSelectChange("showPopupFor"));
 	$("#tracker_enhanced_format").on("change", onSettingSelectChange("trackerFormat"));
@@ -194,11 +185,6 @@ function registerSettingsListeners() {
 	$("#tracker_enhanced_request_prompt").on("input", onSettingInputareaInput("generateRequestPrompt"));
 	$("#tracker_enhanced_roleplay_prompt").on("input", onSettingInputareaInput("roleplayPrompt"));
 	$("#tracker_enhanced_recent_messages").on("input", onSettingInputareaInput("generateRecentMessagesTemplate"));
-	$("#tracker_enhanced_inline_request_prompt").on("input", onSettingInputareaInput("inlineRequestPrompt"));
-	$("#tracker_enhanced_message_summarization_context_template").on("input", onSettingInputareaInput("messageSummarizationContextTemplate"));
-	$("#tracker_enhanced_message_summarization_system_prompt").on("input", onSettingInputareaInput("messageSummarizationSystemPrompt"));
-	$("#tracker_enhanced_message_summarization_request_prompt").on("input", onSettingInputareaInput("messageSummarizationRequestPrompt"));
-	$("#tracker_enhanced_message_summarization_recent_messages").on("input", onSettingInputareaInput("messageSummarizationRecentMessagesTemplate"));
 	$("#tracker_enhanced_character_description").on("input", onSettingInputareaInput("characterDescriptionTemplate"));
 	$("#tracker_enhanced_mes_tracker_template").on("input", onSettingInputareaInput("mesTrackerTemplate"));
 	$("#tracker_enhanced_mes_tracker_javascript").on("input", onSettingInputareaInput("mesTrackerJavascript"));
@@ -657,12 +643,7 @@ function getCurrentPresetSettings() {
 		generateRecentMessagesTemplate: extensionSettings.generateRecentMessagesTemplate,
 		roleplayPrompt: extensionSettings.roleplayPrompt,
 		
-		messageSummarizationContextTemplate: extensionSettings.messageSummarizationContextTemplate,
-		messageSummarizationSystemPrompt: extensionSettings.messageSummarizationSystemPrompt,
-		messageSummarizationRequestPrompt: extensionSettings.messageSummarizationRequestPrompt,
-		messageSummarizationRecentMessagesTemplate: extensionSettings.messageSummarizationRecentMessagesTemplate,
 
-		inlineRequestPrompt: extensionSettings.inlineRequestPrompt,
 		
 		characterDescriptionTemplate: extensionSettings.characterDescriptionTemplate,
 
@@ -705,18 +686,7 @@ function onSettingSelectChange(settingName) {
 	};
 }
 
-/**
- * Event handler for changing the generation mode.
- * Updates the field visibility based on the selected mode.
- */
-function onGenerationModeChange() {
-	const value = $(this).val();
-	extensionSettings.generationMode = value;
-	updateFieldVisibility(value);
-	saveSettingsDebounced();
-}
-
-/**
+/**
  * Returns a function to handle textarea input changes for a given setting.
  * @param {string} settingName The name of the setting.
  * @returns {Function} The event handler function.
@@ -965,7 +935,6 @@ function onTrackerPromptResetClick() {
             
             // Update UI components
             updatePresetDropdown();
-            updateFieldVisibility(extensionSettings.generationMode);
             setSettingsInitialValues();
             processTrackerJavascript();
             
@@ -993,23 +962,6 @@ function onTrackerPromptResetClick() {
  * Updates the visibility of fields based on the selected generation mode.
  * @param {string} mode The current generation mode.
  */
-function updateFieldVisibility(mode) {
-	// Hide all sections first
-	$("#generate_context_section").hide();
-	$("#message_summarization_section").hide();
-	$("#inline_request_section").hide();
-
-	// Show fields based on the selected mode
-	if (mode === generationModes.INLINE) {
-		$("#inline_request_section").show();
-	} else if (mode === generationModes.SINGLE_STAGE) {
-		$("#generate_context_section").show();
-	} else if (mode === generationModes.TWO_STAGE) {
-		$("#generate_context_section").show();
-		$("#message_summarization_section").show();
-	}
-}
-
 // #endregion
 
 // #region Popup Options Management

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -5,8 +5,7 @@ import { getMessageTimeStamp } from "../../../../../scripts/RossAscends-mods.js"
 import { log, debug, getLastMessageWithTracker, getLastNonSystemMessageIndex, getNextNonSystemMessageIndex, getPreviousNonSystemMessageIndex, isSystemMessage, shouldGenerateTracker, shouldShowPopup, warn } from "../lib/utils.js";
 import { extensionSettings } from "../index.js";
 import { generateTracker, getRequestPrompt } from "./generation.js";
-import { generationModes, generationTargets } from "./settings/settings.js";
-import { jsonToYAML, yamlToJSON } from "../lib/ymlParser.js";
+import { generationTargets } from "./settings/settings.js";
 import { FIELD_INCLUDE_OPTIONS, getDefaultTracker, OUTPUT_FORMATS, getTracker as getCleanTracker, trackerExists, cleanTracker } from "./trackerDataHandler.js";
 import { TrackerEditorModal } from "./ui/trackerEditorModal.js";
 import { TrackerPreviewManager } from "./ui/trackerPreviewManager.js";
@@ -61,15 +60,6 @@ export function getTracker(mesNum) {
 	return tracker;
 }
 
-/**
- * Injects the inline prompt into the extension prompt system.
- * @param {boolean} clearTracker - If true, clears the inline prompt.
- */
-export async function injectInlinePrompt(clearTracker = false) {
-	const inlinePrompt = clearTracker ? "" : getRequestPrompt(extensionSettings.inlineRequestPrompt, null, false);
-	if(!clearTracker) debug("Injecting inline prompt:", inlinePrompt);
-	await setExtensionPrompt("inlineTrackerEnhancedPrompt", inlinePrompt, 1, 0, true, EXTENSION_PROMPT_ROLES.SYSTEM);
-}
 
 /**
  * Injects the tracker into the extension prompt system.
@@ -103,94 +93,13 @@ export async function injectTracker(tracker = "", position = 0) {
  */
 export async function clearInjects() {
 	debug("Clearing injects");
-	await injectInlinePrompt(true);
+	await setExtensionPrompt("inlineTrackerEnhancedPrompt", "", 1, 0, true, EXTENSION_PROMPT_ROLES.SYSTEM);
 	await injectTracker("", 0);
 }
 
-/**
- * Adds inline trackers to the specified messages.
- * @param {number} lastMesId - The last message ID to consider.
- * @param {boolean} noSave - If true, skips saving the chat.
- */
-async function addInlineTrackers(lastMesId, noSave = false) {
-	const numberOfMessages = extensionSettings.numberOfMessages === 0 ? chat.length : extensionSettings.numberOfMessages;
-	const messages = chat
-		.slice(0, lastMesId + 1)
-		.map((mes, index) => ({ index, mes }))
-		.filter(({ index, mes }) => !isSystemMessage(index) && mes.tracker)
-		.slice(-numberOfMessages)
-		.map(({ index }) => index);
 
-	for (const mesId of messages) {
-		const mes = chat[mesId];
-		const trackerYAML = jsonToYAML(mes.tracker);
-		mes.mes = `<tracker>${trackerYAML}</tracker>\n\n${mes.mes.trim()}`;
-		mes.has_inline_tracker = true;
-	}
 
-	if (!noSave) await saveChatConditional();
-}
 
-/**
- * Removes inline trackers from messages.
- * @param {boolean} noSave - If true, skips saving the chat.
- */
-export async function removeInlineTrackers(noSave = false) {
-	const messages = chat
-		.slice()
-		.map((mes, index) => ({ index, mes }))
-		.filter(({ mes }) => mes.has_inline_tracker)
-		.map(({ index }) => index);
-
-	for (const mesId of messages) {
-		await extractAndSaveInlineTracker(mesId, true);
-		delete chat[mesId].has_inline_tracker;
-	}
-
-	if (!noSave) await saveChatConditional();
-}
-
-/**
- * Extracts the inline tracker from a message and saves it.
- * @param {number} mesId - The message ID.
- * @param {boolean} noSave - If true, skips saving the chat.
- */
-async function extractAndSaveInlineTracker(mesId, noSave = false) {
-	const mes = chat[mesId];
-
-	// Regex to extract the tracker content
-	const trackerRegex = /<tracker>([\s\S]*?)<\/tracker>/;
-	const trackerMatch = mes.mes.match(trackerRegex);
-
-	if (trackerMatch && !mes.tracker) {
-		const trackerYAML = trackerMatch[1];
-		const tracker = getCleanTracker(trackerYAML, extensionSettings.trackerDef, FIELD_INCLUDE_OPTIONS.ALL, true, OUTPUT_FORMATS.JSON);
-
-		// Save the tracker JSON back to the message object
-		if (tracker) {
-			mes.tracker = tracker;
-			mes.mes = mes.mes.replace(trackerRegex, "").trim();
-		} else {
-			warn(`Failed to parse tracker YAML for message ID ${mesId}`);
-			noSave = true;
-		}
-	}
-
-	if (!noSave) await saveChatConditional();
-
-	TrackerPreviewManager.updatePreview(mesId);
-}
-
-/**
- * Refreshes inline trackers.
- * @param {number} lastMesId - The last message ID to consider.
- * @param {boolean} noSave - If true, skips saving the chat.
- */
-async function refreshInlineTrackers(lastMesId, noSave = false) {
-	await removeInlineTrackers(true);
-	await addInlineTrackers(lastMesId, true);
-	if (!noSave) await saveChatConditional();
-}
 
 //#endregion
 
@@ -205,75 +114,9 @@ async function refreshInlineTrackers(lastMesId, noSave = false) {
 export async function prepareMessageGeneration(type, options, dryRun) {
 	if (!chat_metadata.tracker) chat_metadata.tracker = {};
 
-	if (extensionSettings.generationMode === generationModes.INLINE) {
-		await handleInlineGeneration(type);
-	} else {
-		await handleStagedGeneration(type, options, dryRun);
-	}
+	await handleStagedGeneration(type, options, dryRun);
 }
 
-/**
- * Handles inline message generation.
- * @param {string} type - The type of message generation.
- */
-async function handleInlineGeneration(type) {
-	const mesId = getLastNonSystemMessageIndex();
-	if (type === ACTION_TYPES.CONTINUE) {
-		await refreshInlineTrackers(mesId - 1, true);
-	}
-	if ([ACTION_TYPES.SWIPE, ACTION_TYPES.REGENERATE].includes(type)) {
-		await refreshInlineTrackers(mesId - 1, true);
-		const mes = chat[mesId];
-		if (type === ACTION_TYPES.REGENERATE && mes.tracker && Object.keys(mes.tracker).length !== 0) {
-			const tracker = jsonToYAML(mes.tracker);
-			mes.mes = `<tracker>${tracker}</tracker>\n\n`;
-		} else if (type === ACTION_TYPES.SWIPE && mes.tracker && Object.keys(mes.tracker).length !== 0) {
-			if (mes.swipe_id == null) {
-				mes.swipe_id = 0;
-			}
-			if (!mes.swipes) {
-				mes.swipes = [mes.mes];
-			}
-			if (!mes.swipe_info) {
-				mes.swipe_info = [
-					{
-						send_date: mes.send_date,
-						gen_started: mes.gen_started,
-						gen_finished: mes.gen_finished,
-						extra: structuredClone(mes.extra),
-					},
-				];
-			}
-			const tracker = jsonToYAML(mes.tracker);
-			const trackerString = `<tracker>${tracker}</tracker>\n\n`;
-			mes.swipes.push(trackerString);
-			mes.swipe_info.push({
-				send_date: getMessageTimeStamp(),
-				gen_started: null,
-				gen_finished: null,
-				extra: {
-					bias: extractMessageBias(trackerString),
-					gen_id: Date.now(),
-					api: "manual",
-					model: "slash command",
-				},
-			});
-			mes.swipe_id = mes.swipes.length - 1;
-			mes.mes = trackerString;
-			const mesDom = document.querySelector(`#chat .mes[mesid="${mesId}"]`);
-			mesDom.querySelector(".mes_text").innerHTML = messageFormatting(mes.mes, mes.name, mes.is_system, mes.is_user, Number(mesDom.getAttribute("mesid")));
-			[...mesDom.querySelectorAll(".swipes-counter")].forEach((it) => {
-				it.textContent = `${mes.swipe_id + 1}/${mes.swipes.length}`;
-			});
-		}
-		type = ACTION_TYPES.CONTINUE;
-	} else {
-		await refreshInlineTrackers(mesId, true);
-		await injectInlinePrompt();
-	}
-	chat_metadata.tracker.inlineTrackerId = mesId;
-	await saveChatConditional();
-}
 
 /**
  * Handles staged message generation.
@@ -426,42 +269,33 @@ export async function addTrackerToMessage(mesId) {
 	const manageStopButton = $("#mes_stop").css("display") === "none";
 	if (manageStopButton) deactivateSendButtons();
 	try {
+		/**
+		 * Saves the tracker to the message and updates the chat metadata.
+		 * @param {number} mesId - The message ID.
+		 * @param {object} tracker - The tracker object.
+		 */
+		const saveTrackerToMessage = async (mesId, tracker) => {
+			debug("Adding tracker to message:", { mesId, mes: chat[mesId], tracker });
+			chat[mesId].tracker = tracker;
+			if (typeof chat_metadata.tracker !== "undefined") {
+				chat_metadata.tracker.tempTrackerId = null;
+				chat_metadata.tracker.tempTracker = null;
+				chat_metadata.tracker.cmdTrackerOverride = null;
+			}
+			await saveChatConditional();
+			TrackerPreviewManager.updatePreview(mesId);
 
-	/**
-	 * Saves the tracker to the message and updates the chat metadata.
-	 * @param {number} mesId - The message ID.
-	 * @param {object} tracker - The tracker object.
-	 */
-	const saveTrackerToMessage = async (mesId, tracker) => {
-		debug("Adding tracker to message:", { mesId, mes: chat[mesId], tracker });
-		chat[mesId].tracker = tracker;
-		if(typeof chat_metadata.tracker !== "undefined"){
-			chat_metadata.tracker.tempTrackerId = null;
-			chat_metadata.tracker.tempTracker = null;
-			chat_metadata.tracker.cmdTrackerOverride = null;
+			if (manageStopButton) activateSendButtons();
+		};
+
+		if (isSystemMessage(mesId)) {
+			if (manageStopButton) activateSendButtons();
+			return;
 		}
-		await saveChatConditional();
-		TrackerPreviewManager.updatePreview(mesId);
 
-		if (manageStopButton) activateSendButtons();
-	};
-
-	if (extensionSettings.generationMode === generationModes.INLINE) {
-		const tempId = chat_metadata?.tracker?.inlineTrackerId ?? null;
-		if (getNextNonSystemMessageIndex(tempId) === mesId) {
-			await extractAndSaveInlineTracker(mesId, true);
-			await removeInlineTrackers(true);
-		}
-		if(chat_metadata.tracker) chat_metadata.tracker.inlineTrackerId = null;
-		await saveChatConditional();
-
-		if (manageStopButton) activateSendButtons();
-		return;
-	} else {
-		if(isSystemMessage(mesId)) return;
 		const tempId = chat_metadata?.tracker?.tempTrackerId ?? null;
-		if(chat_metadata?.tracker?.cmdTrackerOverride) {
-			saveTrackerToMessage(mesId, chat_metadata.tracker.cmdTrackerOverride);
+		if (chat_metadata?.tracker?.cmdTrackerOverride) {
+			await saveTrackerToMessage(mesId, chat_metadata.tracker.cmdTrackerOverride);
 		} else if (tempId != null) {
 			debug("Checking for temp tracker match", { mesId, tempId });
 			const trackerMesId = isSystemMessage(tempId) ? getNextNonSystemMessageIndex(tempId) : tempId;
@@ -477,7 +311,6 @@ export async function addTrackerToMessage(mesId) {
 				await saveTrackerToMessage(mesId, tracker);
 			}
 		}
-	}
 	} catch (e) {
 		if (manageStopButton) activateSendButtons();
 	}

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -83,7 +83,9 @@ export async function injectTracker(tracker = "", position = 0) {
 		trackerYAML = cleanTracker(tracker, extensionSettings.trackerDef, OUTPUT_FORMATS.YAML, false);
 		if(trackerYAML != "") {
 			debug("Injecting tracker:", { tracker: trackerYAML, position });
-			trackerYAML = `<tracker>\n${trackerYAML}\n</tracker>`;
+			const roleplayPrompt = (extensionSettings.roleplayPrompt ?? "").trim();
+			const trackerBlock = `<tracker>\n${trackerYAML}\n</tracker>`;
+			trackerYAML = roleplayPrompt ? `${roleplayPrompt}\n${trackerBlock}` : trackerBlock;
 			trackerIncluded = true;
 		}
 	}


### PR DESCRIPTION
05-10-2025
- Added a configurable **“Roleplay Injection Prompt”**, allowing injected tracker payloads to begin with a short guidance line.  
  - This helps the roleplay LLM understand the purpose of the tracker.  
- Removed **Inline** and **Two-Stage** generation models, along with their pipelines and settings.  
  - *Inline* simply injected into the main chat and asked the roleplay LLM to handle the tracker task, which was counterintuitive since it bypassed our independent connection.  
  - *Two-Stage* sent two requests, which I never found useful.  
  - Both were removed to simplify pipelines and settings.