### PR TITLE
feat: add regex preprocessing (catalog-only) + preview UI for Tracker Enhanced

### DIFF
--- a/html/settings.html
+++ b/html/settings.html
@@ -72,6 +72,39 @@
 			</div>
 			<hr class="sysHR" />
 
+			<!-- Regex Preprocessing (UI scaffold) -->
+			<div class="tracker-block m-b-1 m-t-1">
+				<label for="tracker_enhanced_enable_preprocessing">Regex Preprocessing</label><br />
+				<small>Selected regex scripts (from the Regex Engine) will run on messages before tracking.</small><br />
+				<div class="tracker-block flex-container">
+					<input id="tracker_enhanced_enable_preprocessing" type="checkbox" />
+					<label for="tracker_enhanced_enable_preprocessing">Enable preprocessing</label>
+				</div>
+				<label for="tracker_enhanced_regex_scripts">Preprocess with Regex Script(s)</label><br />
+				<select id="tracker_enhanced_regex_scripts" class="text_pole" multiple="multiple">
+					<!-- Options will be populated in Step 2 -->
+				</select>
+				<small>Choose one or more regex scripts…</small>
+
+				<!-- Preview preprocessing -->
+				<div class="tracker-block m-t-1">
+					<label for="tracker_enhanced_regex_preview_input">Preview preprocessing</label><br />
+					<small>Type sample text and run the selected scripts to see the cleaned result.</small><br />
+					<textarea id="tracker_enhanced_regex_preview_input" class="text_pole" rows="3" placeholder="Enter sample text..."></textarea>
+					<div class="flex-container" style="margin-top:6px;">
+						<button id="tracker_enhanced_regex_preview_btn" class="menu_button" style="white-space:nowrap;">Run Preview</button>
+					</div>
+					<div style="margin-top:6px;">
+						<small>Applied (in order): <span id="tracker_enhanced_regex_applied">(none)</span></small>
+					</div>
+					<label for="tracker_enhanced_regex_preview_output" style="display:inline-block;margin-top:6px;">Output</label><br />
+					<textarea id="tracker_enhanced_regex_preview_output" class="text_pole" rows="3" readonly placeholder="Cleaned text will appear here..."></textarea>
+				</div>
+
+			</div>
+			<hr class="sysHR" />
+
+
 			<!-- Preset Management -->
 			<div id="preset_settings">
 				<div class="tracker-block m-b-1 m-t-1">

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -587,6 +587,11 @@ export const defaultSettings = {
 	showPopupFor: generationTargets.NONE,
 
 	trackerFormat: trackerFormat.YAML,
+	
+	// Regex preprocessing (defaults)
+	preprocessingEnabled: false,
+	regexScripts: [],
+
 
 
 

--- a/src/stBridge.js
+++ b/src/stBridge.js
@@ -1,0 +1,156 @@
+// src/stBridge.js
+// Minimal bridge used only by the new regex feature.
+// Uses SillyTavern's regex engine as a CATALOG (to list/resolve scripts by name),
+// and applies selected scripts LOCALLY via standard JS RegExp.replace.
+
+import { debug } from "../lib/utils.js";
+
+/* -------------------------------------------------------------------------- */
+/* Engine catalog bootstrap (async)                                           */
+/* -------------------------------------------------------------------------- */
+
+let engineLoaded = false;
+let getRegexScriptsRef = null;
+
+(async function initRegexEngine() {
+	try {
+		// Update this path only if SillyTavern moves the regex engine.
+		const engine = await import('../../../../../../scripts/extensions/regex/engine.js');
+		getRegexScriptsRef = engine?.getRegexScripts || null;
+		engineLoaded = typeof getRegexScriptsRef === 'function';
+	} catch (err) {
+		console.warn('[Tracker Enhanced] Regex engine catalog failed to load:', err);
+		engineLoaded = false;
+	}
+})();
+
+export function isRegexEngineAvailable() {
+	return engineLoaded === true;
+}
+
+export function getRegexScriptNames() {
+	if (!engineLoaded || typeof getRegexScriptsRef !== 'function') return [];
+	try {
+		const arr = getRegexScriptsRef() || [];
+		const out = [];
+		for (const s of arr) {
+			const n = s?.scriptName || s?.name;
+			if (n) out.push(n);
+		}
+		return out;
+	} catch {
+		return [];
+	}
+}
+
+/* -------------------------------------------------------------------------- */
+/* Local application helpers                                                  */
+/* -------------------------------------------------------------------------- */
+
+// Parse a "/pattern/flags" string (as stored in script.findRegex) to a real RegExp.
+// Falls back to treating the entire string as a pattern with 'g' flag if not slash-delimited.
+function parseFindRegex(findRegex) {
+	if (typeof findRegex !== 'string' || !findRegex.length) return null;
+
+	// Expect formats like "/foo/gi" or plain "foo"
+	if (findRegex.startsWith('/')) {
+		const lastSlash = findRegex.lastIndexOf('/');
+		if (lastSlash > 0) {
+			const pattern = findRegex.slice(1, lastSlash);
+			const flags = findRegex.slice(lastSlash + 1);
+			try {
+				return new RegExp(pattern, flags);
+			} catch {
+				return null;
+			}
+		}
+	}
+
+	// Fallback: treat as a plain pattern with 'g' by default
+	try {
+		return new RegExp(findRegex, 'g');
+	} catch {
+		return null;
+	}
+}
+
+function escapeRegExpLiteral(s) {
+	// Escape user-provided literal text so it cannot act as a regex
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Apply a single script locally to text using JS RegExp.replace.
+// Supports: findRegex + replaceString, and trimStrings (as LITERALS).
+function applyScriptLocally(text, script) {
+	let out = String(text ?? '');
+	if (!script || typeof script !== 'object') return out;
+
+	// Primary find/replace
+	const re = parseFindRegex(script.findRegex);
+	const replace = typeof script.replaceString === 'string' ? script.replaceString : '';
+	if (re) {
+		try {
+			out = out.replace(re, replace);
+		} catch {
+			/* ignore and return current out */
+		}
+	}
+
+	// Optional literal trims
+	if (Array.isArray(script.trimStrings) && script.trimStrings.length) {
+		for (const s of script.trimStrings) {
+			if (typeof s === 'string' && s.length) {
+				try {
+					const lit = new RegExp(escapeRegExpLiteral(s), 'g');
+					out = out.replace(lit, '');
+				} catch {
+					/* ignore invalid patterns */
+				}
+			}
+		}
+	}
+
+	return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Public API                                                                 */
+/* -------------------------------------------------------------------------- */
+
+// Run multiple scripts (by name) on text in sequence; returns a string.
+// Engine is used only to map script names -> script objects; the application is local.
+export function runRegexScriptsOnText(text, names) {
+	let out = String(text ?? '');
+	if (!Array.isArray(names) || names.length === 0) return out;
+
+	// Resolve selected names to script objects using the catalog
+	const byName = Object.create(null);
+	try {
+		if (engineLoaded && typeof getRegexScriptsRef === 'function') {
+			const all = getRegexScriptsRef() || [];
+			for (const s of all) {
+				const n = s?.scriptName || s?.name;
+				if (n) byName[n] = s;
+			}
+		}
+	} catch {
+		// If catalog isn't available yet, byName stays empty and we fall through.
+	}
+
+	for (const name of names) {
+		const sc = byName[name];
+		if (!sc) continue; // if engine not yet loaded or script missing, skip gracefully
+
+		const before = out;
+		const after = applyScriptLocally(before, sc);
+		const changed = before !== after;
+
+		// Debug log is gated by extension debug mode via utils.debug()
+		debug(`[Tracker Enhanced][Regex] applied "${name}" changed=${changed}`);
+		out = after;
+	}
+
+	return out;
+}
+
+// (end bridge)


### PR DESCRIPTION
## What
Adds an optional regex preprocessing step to Tracker Enhanced that scrubs text before it’s used for tracking. Users can choose one or more existing SillyTavern Regex scripts (engine used as a **catalog only**) and apply them locally to recent messages and the {{message}} value. Includes a small Preview tool in settings.

## Why
Lets users remove instructions or other unwanted substrings from messages before they influence tracker state—without depending on the regex engine’s runner semantics. Keeps behavior predictable and fast.

## How
- html/settings.html
  - Regex section: multi-select dropdown (Select2), “Enable preprocessing” toggle, “Preview preprocessing” tool.
  - Minor spacing/UX improvements; “Run Preview” stays on one line.
- src/settings/settings.js
  - Persist toggle + selected scripts; initialize Select2; preview button runs preprocessing.
  - Debug logs routed via `utils.debug()` (only prints when Debug mode is on).
- src/stBridge.js
  - New bridge that uses the ST Regex Engine **only to list/resolve script definitions**.
  - Local application: parse `findRegex` and run standard JS `RegExp.replace` with `replaceString`; `trimStrings` treated as **literals** (escaped) to avoid over-matching.
- src/generation.js
  - Apply preprocessing to each “recent message” entry and to the `{{message}}` text before building prompts (non-destructive; works on local copies).

## Notes
- No changes to tracker field formats or to existing prompts beyond preprocessing text input.
- Engine is not used to execute scripts—only to enumerate available scripts. This reduces coupling and avoids return-shape issues.
- Select2 is visually disabled and interaction-blocked when preprocessing is toggled off.

## Testing
1) Settings → Tracker Enhanced → Regex:
   - Enable preprocessing, select scripts.
   - In Preview, type a sentence containing a target (e.g., “Die Wand ist metallisch…”). Click **Run Preview** → target is removed/replaced.
2) Real run:
   - Send a message with the target token; trigger tracker. The token should not influence or appear in the tracker output.
   - Toggle preprocessing OFF or deselect all scripts → behavior returns to original.
3) Missing scripts:
   - If a previously selected script no longer exists, it’s auto-pruned from the list; no errors.

## Backward compatibility
- Disabled by default (no behavior change unless enabled).
- Keeps existing settings/presets intact.

## Screenshots
- UI: Regex section with Select2 + Preview.
- Before/after tracker output for a message containing a removed token.